### PR TITLE
fix: Categories

### DIFF
--- a/FreshBox/app/src/main/java/com/example/freshbox/data/FoodDao.kt
+++ b/FreshBox/app/src/main/java/com/example/freshbox/data/FoodDao.kt
@@ -88,4 +88,12 @@ interface FoodDao {
     // @param endOfDayMillis 오늘 날짜의 종료 시간 타임스탬프.
     @Query("SELECT * FROM food_items WHERE expiryDate >= :startOfDayMillis AND expiryDate <= :endOfDayMillis")
     suspend fun getItemsExpiringToday(startOfDayMillis: Long, endOfDayMillis: Long): List<FoodItem>
+
+    /**
+     * 특정 카테고리 ID를 가진 모든 식품들의 categoryId를 NULL로 업데이트합니다.
+     * 카테고리가 삭제될 때, 해당 카테고리에 속했던 아이템들을 '미지정' 상태로 만들기 위해 사용됩니다.
+     * @param categoryIdToClear NULL로 변경할 대상 카테고리의 ID.
+     */
+    @Query("UPDATE food_items SET categoryId = NULL WHERE categoryId = :categoryIdToClear")
+    suspend fun clearCategoryIdForItems(categoryIdToClear: Long)
 }

--- a/FreshBox/app/src/main/java/com/example/freshbox/repository/FoodRepository.kt
+++ b/FreshBox/app/src/main/java/com/example/freshbox/repository/FoodRepository.kt
@@ -143,10 +143,16 @@ class FoodRepository(private val foodDao: FoodDao, private val categoryDao: Cate
         return categoryDao.getCategoryByName(name)
     }
 
+    suspend fun deleteCategoryAndUncategorizeItems(category: Category) {
+        // 1. 해당 카테고리 ID를 사용하는 모든 FoodItem의 categoryId를 NULL로 설정합니다.
+        foodDao.clearCategoryIdForItems(category.id)
+        // 2. FoodItem들의 업데이트가 완료된 후, Category를 삭제합니다.
+        categoryDao.deleteCategory(category)
+    }
+
     /**
      * 특정 ID를 가진 Category를 LiveData 형태로 가져옵니다.
      * @param id 조회할 Category의 ID.
-     * @return 해당 ID의 Category를 담은 LiveData (없으면 null 포함 LiveData).
      */
     fun getCategoryById(id: Long): LiveData<Category?> {
         return categoryDao.getCategoryById(id)

--- a/FreshBox/app/src/main/java/com/example/freshbox/ui/list/FoodListViewModel.kt
+++ b/FreshBox/app/src/main/java/com/example/freshbox/ui/list/FoodListViewModel.kt
@@ -2,273 +2,171 @@
 package com.example.freshbox.ui.list
 
 import android.app.Application
-import android.util.Log // 디버깅을 위한 Log 클래스 import
-import androidx.lifecycle.* // ViewModel, LiveData, AndroidViewModel, MediatorLiveData, switchMap 등 사용
-import com.example.freshbox.data.AppDatabase // Room 데이터베이스 클래스
-import com.example.freshbox.data.FoodItem // FoodItem 데이터 Entity
-import com.example.freshbox.data.Category // Category 데이터 Entity
-import com.example.freshbox.repository.FoodRepository // 데이터 로직을 처리하는 Repository
-import kotlinx.coroutines.launch // 코루틴을 사용한 비동기 작업을 위해 import
-import java.time.LocalDate // CalendarFragment에서 날짜 처리를 위해 사용
-import java.time.ZoneId // 시간대 처리를 위해 사용
-// import java.time.temporal.ChronoUnit // 현재 코드에서 직접 사용되지 않으므로 주석 처리
+import android.util.Log
+import androidx.lifecycle.*
+import androidx.lifecycle.map // LiveData 변환(map)을 사용하기 위해 import를 추가합니다.
+import com.example.freshbox.data.AppDatabase
+import com.example.freshbox.data.FoodItem
+import com.example.freshbox.data.Category
+import com.example.freshbox.repository.FoodRepository
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.ZoneId
 
-// 식품 목록 필터링 타입을 정의하는 Enum 클래스
 enum class FoodFilterType { ALL, ACTIVE, EXPIRED, EXPIRING_SOON }
 
-// AndroidViewModel을 상속받아 Application Context를 사용할 수 있도록 함
 class FoodListViewModel(application: Application) : AndroidViewModel(application) {
-    // 데이터베이스 인스턴스 및 DAO, Repository 초기화
-    private val foodDao = AppDatabase.getDatabase(application).foodDao()
-    private val categoryDao = AppDatabase.getDatabase(application).categoryDao()
-    private val repository = FoodRepository(foodDao, categoryDao) // FoodDao와 CategoryDao를 모두 사용
 
-    // --- 원본 데이터 소스 LiveData ---
-    // Repository로부터 가져오는 기본적인 LiveData 목록들. 이들은 Room에 의해 자동으로 업데이트됨.
-    // 이 LiveData들은 주로 내부 필터링 로직의 기본 데이터로 사용됨.
-    private val allFoodItemsFromRepo: LiveData<List<FoodItem>> = repository.getAllFoodItemsSortedByExpiry()
-    private val activeFoodItemsFromRepo: LiveData<List<FoodItem>> = repository.getActiveFoodItems() // 현재 날짜 기준, 만료되지 않은 아이템
-    private val expiredFoodItemsFromRepo: LiveData<List<FoodItem>> = repository.getExpiredFoodItems() // 현재 날짜 기준, 만료된 아이템
+    private val repository: FoodRepository
 
-    // --- UI(Fragment/Activity)에 노출할 LiveData ---
-    // 모든 카테고리 목록 (예: 카테고리 필터 UI 채우기용)
-    val allCategories: LiveData<List<Category>> = repository.getAllCategories()
+    // --- 1. 프로퍼티(변수) 선언부 ---
+    private val allFoodItemsFromRepo: LiveData<List<FoodItem>>
 
-    // --- 필터링 조건 LiveData ---
-    // 현재 선택된 카테고리 ID를 저장하는 MutableLiveData (private)
-    // 외부에서는 setCategoryFilter()를 통해 값을 변경하고, public LiveData를 통해 관찰함.
-    // 초기값 null은 "전체 카테고리"를 의미.
+    // allCategories와 customCategories를 여기서는 타입만 선언합니다.
+    val allCategories: LiveData<List<Category>>
+    val customCategories: LiveData<List<Category>>
+
+    // --- 2. 필터링 조건 LiveData ---
     private val _selectedCategoryId = MutableLiveData<Long?>(null)
-    val selectedCategoryId: LiveData<Long?> = _selectedCategoryId // Fragment에서 관찰할 수 있도록 public으로 노출
-
-    // 현재 입력된 검색 키워드를 저장하는 MutableLiveData (private)
+    val selectedCategoryId: LiveData<Long?> = _selectedCategoryId
     private val _searchedKeyword = MutableLiveData<String?>(null)
-    val searchedKeyword: LiveData<String?> = _searchedKeyword // Fragment에서 관찰할 수 있도록 public으로 노출
+    val searchedKeyword: LiveData<String?> = _searchedKeyword
+    private val _filterTypeForAllActivity = MutableLiveData<FoodFilterType>(FoodFilterType.ALL)
 
+    // --- 3. UI에 노출할 최종 LiveData ---
+    val homeExpiringSoonItems = MediatorLiveData<List<FoodItem>>()
+    val homeExpiredItems = MediatorLiveData<List<FoodItem>>()
+    val filteredFoodItemsForAllActivity = MediatorLiveData<List<FoodItem>>()
+    private val _itemsForCalendarSelectedDate = MutableLiveData<List<FoodItem>>()
+    val itemsForCalendarSelectedDate: LiveData<List<FoodItem>> = _itemsForCalendarSelectedDate
+    val allFoodItemsForCalendar: LiveData<List<FoodItem>>
 
-    // --- HomeFragment용 LiveData ---
-    // MediatorLiveData는 여러 LiveData 소스를 관찰하고, 이들 중 하나라도 변경되면 새로운 값을 발행할 수 있음.
-    // apply { value = emptyList() }는 LiveData가 초기 구독 시 null 대신 빈 리스트를 갖도록 하여 NPE 방지 및 UI 초기 상태 관리에 도움.
-    val homeExpiringSoonItems = MediatorLiveData<List<FoodItem>>().apply { value = emptyList() } // 소비기한 임박 식품 (필터링됨)
-    val homeExpiredItems = MediatorLiveData<List<FoodItem>>().apply { value = emptyList() }     // 소비기한 만료 식품 (필터링됨)
-
-    // --- AllFoodsActivity용 LiveData ---
-    val filteredFoodItemsForAllActivity = MediatorLiveData<List<FoodItem>>().apply { value = emptyList() } // 모든 필터 적용된 목록
-    private val _filterTypeForAllActivity = MutableLiveData<FoodFilterType>(FoodFilterType.ALL) // AllFoodsActivity의 현재 필터 타입
-
-    // --- CalendarFragment용 LiveData ---
-    private val _itemsForCalendarSelectedDate = MutableLiveData<List<FoodItem>>() // 선택된 날짜의 식품 목록 (내부용)
-    val itemsForCalendarSelectedDate: LiveData<List<FoodItem>> = _itemsForCalendarSelectedDate // 외부 노출용
-
-    // CalendarFragment가 전체 아이템 목록을 관찰하여 달력에 날짜별 이벤트(구매/만료)를 표시하기 위함
-    val allFoodItemsForCalendar: LiveData<List<FoodItem>> = allFoodItemsFromRepo
-
-
-    // ViewModel이 생성될 때(초기화 시) 실행되는 블록
+    /**
+     * 클래스 생성 시 실행되는 초기화 블록
+     */
     init {
-        Log.d("FoodListViewModel", "ViewModel initialized. Initial categoryId: ${_selectedCategoryId.value}, keyword: ${_searchedKeyword.value}")
+        val database = AppDatabase.getDatabase(application)
+        repository = FoodRepository(database.foodDao(), database.categoryDao())
 
-        // HomeFragment에서 사용될 homeExpiringSoonItems와 homeExpiredItems MediatorLiveData에 소스들을 추가합니다.
-        // 이 소스들 중 어느 하나라도 값이 변경되면, 지정된 람다 함수(여기서는 updateHomeLists())가 호출됩니다.
-        val homeTriggerSources = listOf<LiveData<*>>(
-            activeFoodItemsFromRepo,  // 원본 활성 식품 목록 (소비기한 임박의 기반)
-            expiredFoodItemsFromRepo, // 원본 만료 식품 목록
-            _selectedCategoryId,      // 카테고리 필터 조건 변경 시
-            _searchedKeyword,       // 검색어 필터 조건 변경 시
-            allCategories             // 전체 카테고리 목록 변경 시 (categoriesMap 업데이트 및 카테고리명 검색에 영향)
-        )
-        homeTriggerSources.forEach { source -> // 각 소스에 대해
-            homeExpiringSoonItems.addSource(source) { // homeExpiringSoonItems가 이 소스를 관찰하도록 추가
-                Log.d("ViewModel_Trigger", "homeExpiringSoonItems triggered by source change: ${source}")
-                updateHomeLists() // 소스 변경 시 homeExpiringSoonItems 값 업데이트
-            }
-            homeExpiredItems.addSource(source) { // homeExpiredItems가 이 소스를 관찰하도록 추가
-                Log.d("ViewModel_Trigger", "homeExpiredItems triggered by source change: ${source}")
-                updateHomeLists() // 소스 변경 시 homeExpiredItems 값 업데이트
-            }
+        // --- 4. 프로퍼티(변수) 초기화(값 할당) 부 ---
+        allFoodItemsFromRepo = repository.getAllFoodItemsSortedByExpiry()
+
+        // 4-1. allCategories를 먼저 초기화합니다.
+        allCategories = repository.getAllCategories()
+
+        // 4-2. 초기화된 allCategories를 사용하여 customCategories를 초기화합니다.
+        //      이 순서가 매우 중요합니다.
+        customCategories = allCategories.map { list ->
+            list.filter { it.isCustom }
         }
-        Log.d("FoodListViewModel", "Sources added for HomeFragment LiveData.")
 
+        allFoodItemsForCalendar = allFoodItemsFromRepo
 
-        // AllFoodsActivity에서 사용될 filteredFoodItemsForAllActivity MediatorLiveData에 소스들을 추가합니다.
-        val allActivityTriggerSources = listOf<LiveData<*>>(
-            _filterTypeForAllActivity, // AllFoodsActivity의 필터 타입 변경 시
-            _selectedCategoryId,       // 공통 카테고리 필터 변경 시
-            _searchedKeyword,        // 공통 검색어 필터 변경 시
-            allFoodItemsFromRepo,      // 모든 식품 목록 (FilterType.ALL 일 때의 기반)
-            activeFoodItemsFromRepo,   // 활성 식품 목록 (FilterType.ACTIVE/EXPIRING_SOON 일 때의 기반)
-            expiredFoodItemsFromRepo,  // 만료 식품 목록 (FilterType.EXPIRED 일 때의 기반)
-            allCategories
-        )
-        allActivityTriggerSources.forEach { source ->
-            filteredFoodItemsForAllActivity.addSource(source) {
-                Log.d("ViewModel_Trigger", "filteredFoodItemsForAllActivity triggered by source change: ${source}")
-                updateFilteredDataForAllActivity() // 소스 변경 시 filteredFoodItemsForAllActivity 값 업데이트
-            }
-        }
-        Log.d("FoodListViewModel", "Sources added for AllFoodsActivity LiveData.")
+        // --- Observer 설정 ---
+        val homeUpdateTrigger = Observer<Any?> { updateHomeLists() }
+        homeExpiringSoonItems.addSource(allFoodItemsFromRepo, homeUpdateTrigger)
+        homeExpiringSoonItems.addSource(_selectedCategoryId, homeUpdateTrigger)
+        homeExpiringSoonItems.addSource(_searchedKeyword, homeUpdateTrigger)
+        homeExpiredItems.addSource(allFoodItemsFromRepo, homeUpdateTrigger)
+        homeExpiredItems.addSource(_selectedCategoryId, homeUpdateTrigger)
+        homeExpiredItems.addSource(_searchedKeyword, homeUpdateTrigger)
 
-        // ViewModel 생성 시 초기 필터 상태를 설정하여 LiveData들이 초기값을 가지도록 합니다.
-        // 이 호출들은 각 MutableLiveData의 값을 변경하고, 결과적으로 연결된 MediatorLiveData의 업데이트 함수를 트리거합니다.
-        // setSearchKeyword(null) // 초기 검색어 없음
-        // setCategoryFilter(null)  // 초기 카테고리 필터 없음 ("전체")
-        // setFilterTypeForAllActivity(FoodFilterType.ALL) // AllFoodsActivity의 기본 필터 타입
-        // -> init 블록에서 LiveData의 초기값을 이미 null 또는 ALL로 설정했으므로,
-        //    여기서 set 메서드를 다시 호출하면 중복되거나 의도치 않은 초기 로딩이 발생할 수 있습니다.
-        //    MediatorLiveData는 소스 LiveData가 첫 값을 발행할 때 또는 값이 변경될 때 반응합니다.
-        //    만약 명시적인 초기 데이터 로딩이 필요하다면, init 마지막에 updateHomeLists(), updateFilteredDataForAllActivity()를 호출할 수 있습니다.
+        val allFoodsUpdateTrigger = Observer<Any?> { updateAllFoodsList() }
+        filteredFoodItemsForAllActivity.addSource(allFoodItemsFromRepo, allFoodsUpdateTrigger)
+        filteredFoodItemsForAllActivity.addSource(_selectedCategoryId, allFoodsUpdateTrigger)
+        filteredFoodItemsForAllActivity.addSource(_searchedKeyword, allFoodsUpdateTrigger)
+        filteredFoodItemsForAllActivity.addSource(_filterTypeForAllActivity, allFoodsUpdateTrigger)
+
+        updateHomeLists()
+        updateAllFoodsList()
     }
 
-    // 여러 LiveData에서 공통으로 사용될 수 있는 필터링 로직 함수
-    // sourceList에 대해 categoryId와 keyword로 필터링하여 결과를 반환합니다.
-    private fun applySharedFilters(
-        sourceList: List<FoodItem>,
-        categoryId: Long?,
-        keyword: String?,
-        categoriesMap: Map<Long, String> // 카테고리 이름으로 검색하기 위해 필요
-    ): List<FoodItem> {
-        var filteredList = sourceList // 원본 리스트로 시작
-        Log.d("FoodListViewModel_Filter", "applySharedFilters - Input size: ${sourceList.size}, categoryId: $categoryId, keyword: '$keyword'")
-
-        // 1. 카테고리 ID로 필터링 (categoryId가 null이 아닐 경우)
-        if (categoryId != null) {
-            filteredList = filteredList.filter { it.categoryId == categoryId }
-        }
-        Log.d("FoodListViewModel_Filter", "applySharedFilters - After Category filter. Result size: ${filteredList.size}")
-
-        // 2. 키워드로 필터링 (keyword가 비어있지 않을 경우)
-        // 식품 이름, 태그, 카테고리 이름(변환된)에 키워드가 포함되어 있는지 확인합니다.
-        if (!keyword.isNullOrBlank()) {
-            filteredList = filteredList.filter { item ->
-                val nameMatch = item.name.lowercase().contains(keyword)
-                val tagMatch = item.tags.any { tag -> tag.lowercase().contains(keyword) }
-                val categoryNameMatch = item.categoryId?.let { catId ->
-                    categoriesMap[catId]?.contains(keyword) // 카테고리 ID로 이름을 찾아 검색어와 비교
-                } ?: false
-                nameMatch || tagMatch || categoryNameMatch // 셋 중 하나라도 일치하면 포함
-            }
-        }
-        Log.d("FoodListViewModel_Filter", "applySharedFilters - After Keyword filter. Result size: ${filteredList.size}")
-        return filteredList // 최종 필터링된 리스트 반환
-    }
-
-    // HomeFragment에 표시될 소비기한 임박 및 만료 목록을 업데이트하는 함수
-    // _selectedCategoryId 또는 _searchedKeyword 등이 변경될 때 호출됩니다.
     private fun updateHomeLists() {
-        val currentKeyword = _searchedKeyword.value?.trim()?.lowercase() // 현재 검색어 (소문자 변환)
-        val currentCategoryId = _selectedCategoryId.value // 현재 선택된 카테고리 ID
-        // 카테고리 ID-이름 Map (allCategories LiveData가 null일 수 있으므로 안전 호출 및 기본값 제공)
+        val allItems = allFoodItemsFromRepo.value ?: return
+        val categoryId = _selectedCategoryId.value
+        val keyword = _searchedKeyword.value?.trim()?.lowercase()
         val categoriesMap = allCategories.value?.associateBy({ it.id }, { it.name.lowercase() }) ?: emptyMap()
 
-        Log.d("FoodListViewModel", "updateHomeLists called. CategoryId: $currentCategoryId, Keyword: '$currentKeyword'")
+        val baseFilteredList = allItems.filter { item ->
+            val categoryMatch = (categoryId == null || item.categoryId == categoryId)
+            val keywordMatch = keyword.isNullOrBlank() ||
+                    item.name.lowercase().contains(keyword) ||
+                    item.tags.any { tag -> tag.lowercase().contains(keyword) } ||
+                    item.categoryId?.let { categoriesMap[it]?.contains(keyword) } == true
+            categoryMatch && keywordMatch
+        }
 
-        // 소비기한 임박 목록 필터링
-        val activeListSource = activeFoodItemsFromRepo.value ?: emptyList() // 원본 활성 식품 목록
-        val expiringSoonBase = activeListSource.filter { it.isExpiringSoon() } // 1차: 소비기한 임박 식품만 필터링
-        Log.d("FoodListViewModel", "Base expiringSoonList (isExpiringSoon only): ${expiringSoonBase.size} items")
-        // 2차: 카테고리 및 키워드로 추가 필터링하여 homeExpiringSoonItems LiveData 값 업데이트
-        homeExpiringSoonItems.value = applySharedFilters(expiringSoonBase, currentCategoryId, currentKeyword, categoriesMap)
-        Log.d("FoodListViewModel", "homeExpiringSoonItems LIVEDATA updated with ${homeExpiringSoonItems.value?.size ?: 0} items.")
-
-        // 소비기한 만료 목록 필터링
-        val expiredListSource = expiredFoodItemsFromRepo.value ?: emptyList() // 원본 만료 식품 목록
-        Log.d("FoodListViewModel", "Base expiredList: ${expiredListSource.size} items")
-        // 카테고리 및 키워드로 필터링하여 homeExpiredItems LiveData 값 업데이트
-        homeExpiredItems.value = applySharedFilters(expiredListSource, currentCategoryId, currentKeyword, categoriesMap)
-        Log.d("FoodListViewModel", "homeExpiredItems LIVEDATA updated with ${homeExpiredItems.value?.size ?: 0} items.")
+        homeExpiredItems.value = baseFilteredList.filter { it.isExpired() }.take(10)
+        homeExpiringSoonItems.value = baseFilteredList.filter { !it.isExpired() && it.isExpiringSoon() }.take(10)
     }
 
-    // AllFoodsActivity에 표시될 전체 필터링된 목록을 업데이트하는 함수
-    private fun updateFilteredDataForAllActivity() {
-        val currentFilterType = _filterTypeForAllActivity.value // 현재 필터 타입 (ALL, ACTIVE 등)
-        val currentCategoryId = _selectedCategoryId.value // 현재 선택된 카테고리 ID
-        val currentKeyword = _searchedKeyword.value?.trim()?.lowercase() // 현재 검색어
+    private fun updateAllFoodsList() {
+        val allItems = allFoodItemsFromRepo.value ?: return
+        val categoryId = _selectedCategoryId.value
+        val keyword = _searchedKeyword.value?.trim()?.lowercase()
+        val filterType = _filterTypeForAllActivity.value ?: FoodFilterType.ALL
         val categoriesMap = allCategories.value?.associateBy({ it.id }, { it.name.lowercase() }) ?: emptyMap()
 
-        Log.d("FoodListViewModel", "updateFilteredDataForAllActivity. CategoryId: $currentCategoryId, Keyword: '$currentKeyword', FilterType: $currentFilterType")
+        val typeFilteredList = when (filterType) {
+            FoodFilterType.ALL -> allItems
+            FoodFilterType.ACTIVE -> allItems.filter { !it.isExpired() }
+            FoodFilterType.EXPIRED -> allItems.filter { it.isExpired() }
+            FoodFilterType.EXPIRING_SOON -> allItems.filter { !it.isExpired() && it.isExpiringSoon() }
+        }
 
-        // 1. 필터 타입에 따라 기본 소스 목록 결정
-        val sourceListBasedOnType = when (currentFilterType) {
-            FoodFilterType.ALL -> allFoodItemsFromRepo.value
-            FoodFilterType.ACTIVE -> activeFoodItemsFromRepo.value
-            FoodFilterType.EXPIRED -> expiredFoodItemsFromRepo.value
-            FoodFilterType.EXPIRING_SOON -> activeFoodItemsFromRepo.value?.filter { it.isExpiringSoon() }
-            null -> allFoodItemsFromRepo.value // 기본값은 전체 목록
-        } ?: emptyList()
-
-        // 2. 카테고리 및 키워드로 추가 필터링하여 filteredFoodItemsForAllActivity LiveData 값 업데이트
-        filteredFoodItemsForAllActivity.value = applySharedFilters(sourceListBasedOnType, currentCategoryId, currentKeyword, categoriesMap)
-        Log.d("FoodListViewModel", "filteredFoodItemsForAllActivity LIVEDATA updated with ${filteredFoodItemsForAllActivity.value?.size ?: 0} items.")
+        val finalList = typeFilteredList.filter { item ->
+            val categoryMatch = (categoryId == null || item.categoryId == categoryId)
+            val keywordMatch = keyword.isNullOrBlank() ||
+                    item.name.lowercase().contains(keyword) ||
+                    item.tags.any { tag -> tag.lowercase().contains(keyword) } ||
+                    item.categoryId?.let { categoriesMap[it]?.contains(keyword) } == true
+            categoryMatch && keywordMatch
+        }
+        filteredFoodItemsForAllActivity.value = finalList
     }
 
-    // --- Public methods for UI (Fragment/Activity) to call to set filters ---
-
-    // AllFoodsActivity에서 필터 타입을 설정하는 함수
-    fun setFilterTypeForAllActivity(filterType: FoodFilterType) {
-        // 현재 필터 타입과 다를 경우에만 업데이트 (불필요한 LiveData 업데이트 방지)
-        if (_filterTypeForAllActivity.value != filterType) {
-            Log.d("FoodListViewModel", "setFilterTypeForAllActivity: $filterType")
-            _filterTypeForAllActivity.value = filterType
-        } else {
-            // 이미 같은 필터 타입이라도, 다른 필터(카테고리, 검색어)가 변경되었을 수 있으므로
-            // filteredFoodItemsForAllActivity를 강제로 다시 계산하도록 호출 (선택적)
-            updateFilteredDataForAllActivity()
+    // --- Public methods for UI ---
+    /**
+     * 특정 카테고리를 안전하게 삭제하는 함수입니다. (UI에서 호출)
+     * Repository를 통해 카테고리 삭제 및 관련 아이템들의 상태 업데이트를 요청합니다.
+     * @param category 삭제할 Category 객체.
+     */
+    fun deleteCategory(category: Category) {
+        viewModelScope.launch {
+            repository.deleteCategoryAndUncategorizeItems(category)
         }
     }
 
-    // 공용 카테고리 필터를 설정하는 함수 (HomeFragment, AllFoodsActivity 등에서 호출 가능)
     fun setCategoryFilter(categoryId: Long?) {
-        // 현재 선택된 카테고리 ID와 다를 경우에만 업데이트
         if (_selectedCategoryId.value != categoryId) {
-            Log.d("FoodListViewModel", "setCategoryFilter: $categoryId. Old value: ${_selectedCategoryId.value}")
-            _selectedCategoryId.value = categoryId // private _selectedCategoryId 업데이트 -> 연결된 MediatorLiveData들 트리거
-        } else if (categoryId == null && _selectedCategoryId.value == null) {
-            // 만약 "전체"(null)가 이미 선택된 상태에서 다시 "전체"를 선택한 경우,
-            // 다른 필터(예: 검색어)가 적용된 상태를 해제하고 싶을 수 있으므로,
-            // LiveData 값을 강제로 다시 설정하여 Observer를 트리거할 수 있음 (또는 update 함수 직접 호출)
-            Log.d("FoodListViewModel", "setCategoryFilter: re-setting to null (all categories) to potentially refresh lists with other filters cleared.")
-            _selectedCategoryId.value = null // 값을 다시 설정하여 Observer 호출 유도 (주의: LiveData는 값이 실제로 변경되어야 알림)
-            // 이 경우, 검색어도 함께 초기화하는 등의 정책을 고려할 수 있음.
+            _selectedCategoryId.value = categoryId
         }
     }
 
-    // 공용 검색어를 설정하는 함수
     fun setSearchKeyword(keyword: String?) {
-        val newKeyword = keyword?.trim()?.ifEmpty { null } // 앞뒤 공백 제거 및 빈 문자열이면 null 처리
-        // 현재 검색어와 다를 경우에만 업데이트
+        val newKeyword = keyword?.trim()?.ifEmpty { null }
         if (_searchedKeyword.value != newKeyword) {
-            Log.d("FoodListViewModel", "_searchedKeyword LiveData updated to: '$newKeyword' by setSearchKeyword")
-            _searchedKeyword.value = newKeyword // private _searchedKeyword 업데이트 -> 연결된 MediatorLiveData들 트리거
-        } else if (newKeyword == null && _searchedKeyword.value != null) {
-            // 검색어가 있다가 없어졌을 때 (사용자가 검색창을 비웠을 때) 명시적으로 null로 설정하여 업데이트 트리거
-            Log.d("FoodListViewModel", "_searchedKeyword explicitly set to null as newKeyword is null and old was not.")
-            _searchedKeyword.value = null
+            _searchedKeyword.value = newKeyword
         }
     }
 
-    // 식품 아이템을 삭제하는 함수 (코루틴 내에서 비동기 실행)
+    fun setFilterTypeForAllActivity(filterType: FoodFilterType) {
+        if (_filterTypeForAllActivity.value != filterType) {
+            _filterTypeForAllActivity.value = filterType
+        }
+    }
+
     fun deleteFoodItem(foodItem: FoodItem) = viewModelScope.launch {
         repository.deleteFoodItem(foodItem)
-        // Room의 LiveData는 데이터 변경을 자동으로 감지하므로, 삭제 후 목록은 자동으로 업데이트됨.
     }
 
-    // CalendarFragment에서 특정 날짜에 만료되는 식품 목록을 로드하는 함수
     fun loadItemsExpiringOnDate(selectedDate: LocalDate) {
-        viewModelScope.launch { // 코루틴 스코프에서 실행
-            Log.d("FoodListViewModel", "loadItemsExpiringOnDate called for: $selectedDate")
-            // 선택된 LocalDate를 해당 날짜의 시작과 끝 타임스탬프(Long)로 변환
-            val startOfDay = selectedDate.atStartOfDay(ZoneId.systemDefault()) // 시스템 기본 시간대로 설정
-            val endOfDay = startOfDay.plusDays(1).minusNanos(1) // 해당 날짜의 가장 마지막 순간 (23:59:59.999...)
-
+        viewModelScope.launch {
+            val startOfDay = selectedDate.atStartOfDay(ZoneId.systemDefault())
+            val endOfDay = startOfDay.plusDays(1).minusNanos(1)
             val startTimestamp = startOfDay.toInstant().toEpochMilli()
             val endTimestamp = endOfDay.toInstant().toEpochMilli()
-
-            Log.d("FoodListViewModel", "Querying for calendar items between $startTimestamp and $endTimestamp")
-            // Repository를 통해 해당 기간의 만료 식품 목록을 가져옴 (suspend 함수 호출)
-            val items = repository.getFoodItemsExpiringBetween(startTimestamp, endTimestamp)
-            // 결과를 _itemsForCalendarSelectedDate LiveData에 할당하여 UI에 알림
-            _itemsForCalendarSelectedDate.value = items
-            Log.d("FoodListViewModel", "Items loaded for $selectedDate (calendar): ${items.size}")
+            _itemsForCalendarSelectedDate.value = repository.getFoodItemsExpiringBetween(startTimestamp, endTimestamp)
         }
     }
 }

--- a/FreshBox/app/src/main/java/com/example/freshbox/ui/list/HomeFragment.kt
+++ b/FreshBox/app/src/main/java/com/example/freshbox/ui/list/HomeFragment.kt
@@ -2,8 +2,7 @@
 package com.example.freshbox.ui.list
 
 import android.app.AlertDialog
-// import android.content.Context // Context는 requireContext()로 가져오므로 명시적 import는 보통 불필요
-import android.content.DialogInterface // AlertDialog 리스너에서 사용
+import android.content.DialogInterface
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.os.Bundle
@@ -13,85 +12,55 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.AdapterView // AutoCompleteTextView의 onItemClickListener 사용을 위해 필요
 import android.widget.ArrayAdapter
 import android.widget.ImageView
 import android.widget.TextView
+import android.widget.Toast
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels // KTX를 사용한 ViewModel 초기화를 위해 필요
-import androidx.lifecycle.Observer // LiveData를 관찰하기 위해 필요
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.example.freshbox.R // 리소스 ID 참조 (예: R.string.theme_light)
-import com.example.freshbox.data.Category // Category 데이터 모델
-import com.example.freshbox.data.FoodItem // FoodItem 데이터 모델 (Room Entity)
-import com.example.freshbox.databinding.FragmentHomeBinding // ViewBinding 클래스
-import com.example.freshbox.ui.addedit.AddFoodBottomSheetFragment // 식품 추가/수정 UI
-import com.example.freshbox.ui.all.AllFoodsActivity // 전체 식품 목록 Activity
-import com.example.freshbox.util.ThemeHelper // 테마 변경 유틸리티
-import java.io.File // 이미지 파일 접근
-import java.text.SimpleDateFormat // 날짜 포맷팅
-import java.util.* // Date, Calendar, Locale 등
+import com.example.freshbox.R
+import com.example.freshbox.data.Category
+import com.example.freshbox.data.FoodItem
+import com.example.freshbox.databinding.FragmentHomeBinding
+import com.example.freshbox.ui.addedit.AddFoodBottomSheetFragment
+import com.example.freshbox.ui.all.AllFoodsActivity
+import com.example.freshbox.util.ThemeHelper
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.*
 
-// 앱의 홈 화면을 담당하는 메인 Fragment
 class HomeFragment : Fragment() {
-    // ViewBinding을 위한 프로퍼티
-    // _binding은 nullable이지만, onDestroyView에서 null로 설정하여 메모리 누수 방지
     private var _binding: FragmentHomeBinding? = null
-    // binding 프로퍼티는 _binding이 null이 아님을 보장하여 UI 요소 접근 시 null 체크를 줄여줌
-    // (onCreateView에서 초기화되고 onDestroyView에서 해제됨)
     private val binding get() = _binding!!
 
-    // FoodListViewModel 인스턴스를 KTX의 by viewModels() 델리게이트를 사용하여 가져옴
-    // Fragment의 생명주기에 맞춰 ViewModel이 관리됨
     private val viewModel: FoodListViewModel by viewModels()
 
-    // 소비기한 만료 식품 목록을 위한 RecyclerView 어댑터
     private lateinit var expiredAdapter: FoodListAdapter
-    // 소비기한 임박 식품 목록을 위한 RecyclerView 어댑터
     private lateinit var expiringAdapter: FoodListAdapter
 
-    // 날짜 표시 형식을 정의하는 SimpleDateFormat 객체
     private val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
-    // 카테고리 ID(Long)를 카테고리 이름(String)으로 매핑하기 위한 Map
-    // ViewModel로부터 전체 카테고리 목록을 받으면 이 Map이 업데이트됨 (상세 정보 표시 등에 사용)
     private var allCategoriesMap: Map<Long, String> = emptyMap()
-
-    // 카테고리 필터 AutoCompleteTextView에 표시될 문자열 목록 (예: "전체", "과일", "채소")
-    private var categoryFilterDisplayList: MutableList<String> = mutableListOf()
-    // ViewModel로부터 받은 실제 Category 객체 목록. 선택된 이름으로 ID를 찾을 때 사용.
     private var actualCategoryList: List<Category> = emptyList()
-    // AutoCompleteTextView에 사용될 ArrayAdapter
-    private lateinit var categoryFilterAdapter: ArrayAdapter<String>
-    // 사용자가 필터에서 현재 선택한 카테고리 이름을 임시 저장 (UI 상태 복원 시도용)
-    // Fragment 재생성 시 이 값은 초기화될 수 있으므로 ViewModel 상태와 동기화하는 로직이 중요.
-    private var currentSelectedCategoryNameInFilter: String? = null
 
-
-    // Fragment의 View를 생성하고 반환하는 메서드
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        // FragmentHomeBinding을 사용하여 fragment_home.xml 레이아웃을 inflate
         _binding = FragmentHomeBinding.inflate(inflater, container, false)
-        // inflate된 레이아웃의 루트 View를 반환
         return binding.root
     }
 
-    // Fragment의 View가 성공적으로 생성된 후 호출되는 메서드
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        // UI 관련 초기화 함수들 호출
-        setupAdapters()         // RecyclerView 어댑터들 초기화
-        setupRecyclerViews()    // RecyclerView들 설정 (LayoutManager, Adapter 연결)
-        setupCategoryFilter()   // 카테고리 필터 UI (AutoCompleteTextView) 설정
-        setupListeners()        // 각종 버튼 및 UI 요소들의 이벤트 리스너 설정
-        observeViewModel()      // ViewModel의 LiveData 관찰 시작하여 UI 업데이트
+        setupAdapters()
+        setupRecyclerViews()
+        setupCategoryFilterListener()
+        setupListeners()
+        observeViewModel()
     }
 
-    // RecyclerView 어댑터들을 초기화하는 함수
     private fun setupAdapters() {
         expiredAdapter = FoodListAdapter(
-            onItemClick = { foodItem -> showFoodDetailDialog(foodItem) }, // 아이템 클릭 시 상세 정보 표시
-            onItemLongClick = { foodItem -> showDeleteConfirmationDialog(foodItem) } // 아이템 롱클릭 시 삭제 확인
+            onItemClick = { foodItem -> showFoodDetailDialog(foodItem) },
+            onItemLongClick = { foodItem -> showDeleteConfirmationDialog(foodItem) }
         )
         expiringAdapter = FoodListAdapter(
             onItemClick = { foodItem -> showFoodDetailDialog(foodItem) },
@@ -99,220 +68,167 @@ class HomeFragment : Fragment() {
         )
     }
 
-    // RecyclerView들을 설정하는 함수
     private fun setupRecyclerViews() {
-        // 소비기한 만료 식품 목록 RecyclerView 설정
-        binding.recyclerViewExpired.layoutManager =
-            LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false) // 가로 스크롤
+        binding.recyclerViewExpired.layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
         binding.recyclerViewExpired.adapter = expiredAdapter
-
-        // 소비기한 임박 식품 목록 RecyclerView 설정
-        binding.recyclerViewExpiring.layoutManager =
-            LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false) // 가로 스크롤
+        binding.recyclerViewExpiring.layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
         binding.recyclerViewExpiring.adapter = expiringAdapter
     }
 
-    // 카테고리 필터 UI(AutoCompleteTextView)를 설정하는 함수
-    private fun setupCategoryFilter() {
-        // ArrayAdapter 초기화. categoryFilterDisplayList는 처음에는 비어있음.
-        // 실제 데이터는 observeViewModel에서 viewModel.allCategories를 관찰하여 채워짐.
-        categoryFilterAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_dropdown_item_1line, categoryFilterDisplayList)
-        // XML 레이아웃의 autoCompleteCategoryFilter ID를 가진 AutoCompleteTextView에 어댑터 설정
-        binding.autoCompleteCategoryFilter.setAdapter(categoryFilterAdapter)
-
-        // 사용자가 드롭다운 목록에서 특정 카테고리를 "선택"했을 때의 동작 정의
+    private fun setupCategoryFilterListener() {
         binding.autoCompleteCategoryFilter.setOnItemClickListener { parent, _, position, _ ->
-            val selectedName = parent.getItemAtPosition(position) as String // 선택된 카테고리 이름
-            currentSelectedCategoryNameInFilter = selectedName // 현재 선택된 이름을 임시 저장 (UI 복원 시도용)
-
-            // 선택된 이름에 따라 ViewModel에 전달할 categoryId 결정
-            var categoryIdToSet: Long? = null
-            if (selectedName == "전체") { // "전체" 옵션 선택 시
-                categoryIdToSet = null // categoryId를 null로 설정하여 전체 목록을 보도록 함
+            val selectedName = parent.getItemAtPosition(position) as String
+            val categoryIdToSet: Long? = if (selectedName == "전체") {
+                null
             } else {
-                // "전체"가 아닐 경우, actualCategoryList(실제 Category 객체 목록)에서 해당 이름을 가진 Category를 찾아 ID를 가져옴
-                val selectedCategory = actualCategoryList.find { it.name == selectedName }
-                categoryIdToSet = selectedCategory?.id
+                actualCategoryList.find { it.name == selectedName }?.id
             }
-            Log.d("HomeFragment_Category", "Category selected: '$selectedName', ID to set in ViewModel: $categoryIdToSet")
-            // ViewModel에 선택된 카테고리 필터 값 설정 요청
-            // (ViewModel 내부에서는 이 값 변경 시 LiveData를 업데이트하여 목록을 다시 필터링해야 함)
             viewModel.setCategoryFilter(categoryIdToSet)
         }
     }
 
-    // 주요 UI 요소들의 이벤트 리스너를 설정하는 함수
     private fun setupListeners() {
-        // FAB(Floating Action Button) 클릭 시 식품 추가 BottomSheet 표시
         binding.fabAddItem.setOnClickListener {
-            // AddFoodBottomSheetFragment의 companion object에 TAG가 정의되어 있어야 함
             AddFoodBottomSheetFragment().show(parentFragmentManager, AddFoodBottomSheetFragment.TAG)
         }
-        // "전체 보기" 버튼 클릭 시 AllFoodsActivity 실행
         binding.buttonViewAll.setOnClickListener {
             startActivity(Intent(requireContext(), AllFoodsActivity::class.java))
         }
-        // 검색창(editTextSearch)의 텍스트 변경 감지 리스너
         binding.editTextSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-            // 텍스트가 변경될 때마다 호출됨
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                val keyword = s.toString().trim().ifEmpty { null } // 입력된 텍스트 (공백 제거, 비었으면 null)
-                Log.d("HomeFragment_Search", "Search keyword input: $keyword")
-                viewModel.setSearchKeyword(keyword) // ViewModel에 검색어 전달하여 필터링 요청
+                val keyword = s.toString().trim().ifEmpty { null }
+                viewModel.setSearchKeyword(keyword)
             }
             override fun afterTextChanged(s: Editable?) {}
         })
-
-        // 설정 아이콘(imageViewSettings) 클릭 시 테마 선택 다이얼로그 표시
-        // fragment_home.xml에 imageViewSettings ID가 있어야 함
         binding.imageViewSettings.setOnClickListener {
-            showThemeSelectionDialog() // 아래 정의된 테마 선택 다이얼로그 표시 함수 호출
+            showThemeSelectionDialog()
         }
-        // 카테고리 필터의 아이템 클릭 리스너는 setupCategoryFilter()에서 이미 설정됨
+
+        // '카테고리 관리' 아이콘 버튼에 대한 클릭 리스너 설정
+        binding.imageViewManageCategories.setOnClickListener {
+            showCategoryManagementDialog()
+        }
     }
 
-    // 테마 선택 다이얼로그를 표시하는 함수
-    private fun showThemeSelectionDialog() {
-        // 다이얼로그에 표시될 옵션 문자열 (R.string.* 리소스 참조)
-        val themeOptions = arrayOf(
-            getString(R.string.theme_light),
-            getString(R.string.theme_dark),
-            getString(R.string.theme_system_default)
-        )
-        // 각 옵션에 해당하는 실제 테마 모드 값 (ThemeHelper에 정의된 상수)
-        val themeModes = intArrayOf(
-            ThemeHelper.LIGHT_MODE,
-            ThemeHelper.DARK_MODE,
-            ThemeHelper.DEFAULT_MODE
-        )
-        // 현재 적용된 테마 모드 가져오기
-        val currentThemeMode = ThemeHelper.getThemeMode(requireContext())
-        // 현재 테마에 해당하는 옵션의 인덱스 찾기 (다이얼로그에서 기본 선택으로 표시)
-        var checkedItem = themeModes.indexOf(currentThemeMode)
-        if (checkedItem == -1) { // 저장된 값이 없거나 배열에 없는 예외적인 경우
-            checkedItem = themeModes.indexOf(ThemeHelper.DEFAULT_MODE) // 시스템 기본 설정을 우선
-            if (checkedItem == -1) checkedItem = 0 // 그래도 없으면 첫 번째 옵션(라이트 모드)을 기본으로
+    /**
+     * 사용자가 직접 추가한 카테고리를 관리(삭제)할 수 있는 다이얼로그를 표시합니다.
+     */
+    private fun showCategoryManagementDialog() {
+        // ViewModel의 .value를 직접 읽는 대신, LiveData 옵저버를 통해 이미 업데이트된
+        // 프래그먼트의 'actualCategoryList'를 사용합니다. 이렇게 하면 타이밍 문제를 피할 수 있습니다.
+        val customCategories = actualCategoryList.filter { it.isCustom }
+
+        // 삭제할 카테고리가 없으면 사용자에게 Toast 메시지를 보여주고 함수를 종료합니다.
+        if (customCategories.isEmpty()) {
+            Toast.makeText(requireContext(), "삭제할 수 있는 카테고리가 없습니다.", Toast.LENGTH_SHORT).show()
+            return
         }
 
-        // AlertDialog 생성 및 표시
+        // 다이얼로그에 표시할 카테고리 이름 목록을 만듭니다.
+        val categoryNames = customCategories.map { it.name }.toTypedArray()
+
+        // AlertDialog를 생성하여 카테고리 목록을 보여줍니다.
         AlertDialog.Builder(requireContext())
-            .setTitle(R.string.theme_dialog_title) // 다이얼로그 제목
-            .setSingleChoiceItems(themeOptions, checkedItem) { dialog: DialogInterface, which: Int -> // 단일 선택 목록, dialog 타입 명시
-                val selectedMode = themeModes[which] // 사용자가 선택한 테마 모드 값
-                // 현재 테마와 사용자가 선택한 테마가 다를 경우에만 변경 작업 수행
-                if (ThemeHelper.getThemeMode(requireContext()) != selectedMode) {
-                    ThemeHelper.setThemeMode(requireContext(), selectedMode) // 선택된 테마 저장 및 즉시 적용 요청
-                    activity?.recreate() // 테마 변경을 화면에 즉시 반영하기 위해 Activity 재시작
-                }
-                dialog.dismiss() // 다이얼로그 닫기
-            }
-            .setNegativeButton("취소", null) // "취소" 버튼
-            .show()
-    }
+            .setTitle("카테고리 삭제")
+            .setItems(categoryNames) { dialog, which ->
+                // 사용자가 목록에서 특정 카테고리를 선택했을 때
+                val selectedCategory = customCategories[which]
 
-    // ViewModel의 LiveData들을 관찰하여 UI를 업데이트하는 함수
-    private fun observeViewModel() {
-        // 1. ViewModel의 전체 카테고리 목록(allCategories) 관찰
-        viewModel.allCategories.observe(viewLifecycleOwner, Observer { categories: List<Category>? -> // categories 타입을 List<Category>?로 받음
-            Log.d("HomeFragment_Observe", "allCategories Observer. Received: ${categories?.size ?: "null"} categories")
-            actualCategoryList = categories ?: emptyList() // null이면 빈 리스트로 초기화, 실제 Category 객체 리스트 업데이트
-            allCategoriesMap = actualCategoryList.associateBy({ it.id }, { it.name }) // ID-이름 Map 생성
-
-            // 카테고리 필터 드롭다운에 표시될 이름 목록 업데이트
-            categoryFilterDisplayList.clear()
-            categoryFilterDisplayList.add("전체") // "전체" 옵션 추가
-            categoryFilterDisplayList.addAll(actualCategoryList.map { it.name }) // 실제 카테고리 이름들 추가
-            // 어댑터에 데이터 변경 알림 (어댑터가 초기화된 후에 호출되어야 함)
-            if (::categoryFilterAdapter.isInitialized) {
-                categoryFilterAdapter.notifyDataSetChanged()
-            }
-            Log.d("HomeFragment_Observe", "Category filter adapter updated. DisplayList size: ${categoryFilterDisplayList.size}.")
-
-            // currentSelectedCategoryNameInFilter를 사용하여 AutoCompleteTextView의 텍스트를 설정.
-            // 이 방식은 Fragment 재생성 시 currentSelectedCategoryNameInFilter가 초기화될 수 있어
-            // 테마 변경 후 카테고리 선택 상태가 "전체"로 돌아갈 수 있음.
-            // 더 안정적인 방법은 ViewModel의 selectedCategoryId를 관찰하여 UI를 업데이트하는 것.
-            currentSelectedCategoryNameInFilter?.let { name ->
-                if (categoryFilterDisplayList.contains(name)) {
-                    binding.autoCompleteCategoryFilter.setText(name, false) // false: onItemClickListener 트리거 방지
-                } else { // 이전에 선택한 이름이 현재 목록에 없으면 "전체"로 설정
-                    binding.autoCompleteCategoryFilter.setText("전체", false)
-                    // 현재 선택된 카테고리 이름이 목록에 없으므로, ViewModel의 필터도 "전체"(null)로 설정할지 고려.
-                    // (사용자가 "전체"를 의도한 것과 다를 수 있으므로 주의)
-                    if (viewModel.selectedCategoryId.value != null) {
-                        // viewModel.setCategoryFilter(null) // 주석 처리: 이로 인해 의도치 않은 필터링 발생 가능
+                // 삭제를 한 번 더 확인하는 다이얼로그를 띄웁니다.
+                AlertDialog.Builder(requireContext())
+                    .setTitle("삭제 확인")
+                    .setMessage("'${selectedCategory.name}' 카테고리를 삭제하시겠습니까?\n\n해당 카테고리의 모든 식품은 '미지정' 상태로 변경됩니다.")
+                    .setPositiveButton("삭제") { _, _ ->
+                        // ViewModel의 deleteCategory 함수를 호출하여 삭제를 실행합니다.
+                        viewModel.deleteCategory(selectedCategory)
+                        Toast.makeText(requireContext(), "'${selectedCategory.name}' 카테고리가 삭제되었습니다.", Toast.LENGTH_SHORT).show()
                     }
-                    currentSelectedCategoryNameInFilter = "전체" // 임시 상태도 업데이트
-                }
-            } ?: run { // 이전에 선택된 이름이 없으면(null이면) "전체"로 기본 설정
-                binding.autoCompleteCategoryFilter.setText("전체", false)
+                    .setNegativeButton("취소", null)
+                    .show()
             }
-        })
-
-        // (주석) ViewModel의 selectedCategoryId 변경을 직접 관찰하여 UI를 동기화하는 옵저버를
-        // 추가하는 것을 이전 답변에서 제안했었습니다. 이는 테마 변경 후 카테고리 필터 상태를
-        // ViewModel의 상태와 일치시키는 데 더 안정적일 수 있습니다.
-        // 예: viewModel.selectedCategoryId.observe(viewLifecycleOwner, Observer { categoryId ->
-        //         updateAutoCompleteTextViewWithVmState(categoryId) // 헬퍼 함수 사용
-        //     })
-
-
-        // 2. 필터링된 소비기한 임박 식품 목록(homeExpiringSoonItems) 관찰
-        viewModel.homeExpiringSoonItems.observe(viewLifecycleOwner, Observer { items: List<FoodItem>? -> // items 타입을 List<FoodItem>?로 받음
-            Log.d("HomeFragment_Observe", "Observed homeExpiringSoonItems. Count: ${items?.size ?: 0}")
-            // 최대 10개 또는 원하는 개수만큼 가져오기 (null이면 빈 리스트)
-            expiringAdapter.submitList(items?.take(10) ?: emptyList()) // 어댑터에 새 목록 제출
-            // "식품 없음" 메시지 관련 기능은 사용자 요청에 따라 updateEmptyViewVisibility 함수 호출을 제거한 상태
-        })
-
-        // 3. 필터링된 소비기한 만료 식품 목록(homeExpiredItems) 관찰
-        viewModel.homeExpiredItems.observe(viewLifecycleOwner, Observer { items: List<FoodItem>? -> // items 타입을 List<FoodItem>?로 받음
-            Log.d("HomeFragment_Observe", "Observed homeExpiredItems. Count: ${items?.size ?: 0}")
-            expiredAdapter.submitList(items?.take(10) ?: emptyList())
-            // "식품 없음" 메시지 관련 기능은 사용자 요청에 따라 updateEmptyViewVisibility 함수 호출을 제거한 상태
-        })
-    }
-
-    // 식품 삭제 확인 다이얼로그를 표시하는 함수
-    private fun showDeleteConfirmationDialog(item: FoodItem) {
-        AlertDialog.Builder(requireContext())
-            .setTitle("삭제 확인")
-            .setMessage("'${item.name}' 항목을 삭제하시겠습니까?")
-            .setPositiveButton("삭제") { _, _ -> viewModel.deleteFoodItem(item) } // ViewModel을 통해 삭제 처리
             .setNegativeButton("취소", null)
             .show()
     }
 
-    // 식품 상세 정보 다이얼로그를 표시하는 함수
-    private fun showFoodDetailDialog(item: FoodItem) {
-        // dialog_food_detail.xml 레이아웃을 inflate
-        val dialogView = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_food_detail, null)
-        val imageView = dialogView.findViewById<ImageView>(R.id.imageViewFood) // ID로 ImageView 찾기
+    private fun showThemeSelectionDialog() {
+        val themeOptions = arrayOf(getString(R.string.theme_light), getString(R.string.theme_dark), getString(R.string.theme_system_default))
+        val themeModes = intArrayOf(ThemeHelper.LIGHT_MODE, ThemeHelper.DARK_MODE, ThemeHelper.DEFAULT_MODE)
+        val currentThemeMode = ThemeHelper.getThemeMode(requireContext())
+        var checkedItem = themeModes.indexOf(currentThemeMode).let { if (it == -1) 0 else it }
 
-        // 이미지 경로가 있으면 이미지 로드, 없으면 플레이스홀더 표시
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.theme_dialog_title)
+            .setSingleChoiceItems(themeOptions, checkedItem) { dialog: DialogInterface, which: Int ->
+                val selectedMode = themeModes[which]
+                if (ThemeHelper.getThemeMode(requireContext()) != selectedMode) {
+                    ThemeHelper.setThemeMode(requireContext(), selectedMode)
+                    activity?.recreate()
+                }
+                dialog.dismiss()
+            }
+            .setNegativeButton("취소", null)
+            .show()
+    }
+
+    private fun observeViewModel() {
+        viewModel.allCategories.observe(viewLifecycleOwner) { categories ->
+            actualCategoryList = categories ?: emptyList()
+            allCategoriesMap = actualCategoryList.associateBy({ it.id }, { it.name })
+            val categoryNames = mutableListOf("전체")
+            categoryNames.addAll(actualCategoryList.map { it.name })
+            val newAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_dropdown_item_1line, categoryNames)
+            binding.autoCompleteCategoryFilter.setAdapter(newAdapter)
+        }
+
+        viewModel.selectedCategoryId.observe(viewLifecycleOwner) { categoryId ->
+            val categoryName = if (categoryId == null) "전체" else allCategoriesMap[categoryId] ?: "전체"
+            if (binding.autoCompleteCategoryFilter.text.toString() != categoryName) {
+                binding.autoCompleteCategoryFilter.setText(categoryName, false)
+            }
+        }
+
+        viewModel.homeExpiredItems.observe(viewLifecycleOwner) { items ->
+            expiredAdapter.submitList(items)
+        }
+        viewModel.homeExpiringSoonItems.observe(viewLifecycleOwner) { items ->
+            expiringAdapter.submitList(items)
+        }
+    }
+
+    private fun showDeleteConfirmationDialog(item: FoodItem) {
+        AlertDialog.Builder(requireContext())
+            .setTitle("삭제 확인")
+            .setMessage("'${item.name}' 항목을 삭제하시겠습니까?")
+            .setPositiveButton("삭제") { _, _ -> viewModel.deleteFoodItem(item) }
+            .setNegativeButton("취소", null)
+            .show()
+    }
+
+    private fun showFoodDetailDialog(item: FoodItem) {
+        val dialogView = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_food_detail, null)
+        val imageView = dialogView.findViewById<ImageView>(R.id.imageViewFood)
+
         item.imagePath?.let { path ->
             if (path.isNotEmpty()) {
                 val imageFile = File(path)
                 if (imageFile.exists()) {
                     BitmapFactory.decodeFile(imageFile.absolutePath)?.let { imageView.setImageBitmap(it) }
-                        ?: imageView.setImageResource(R.drawable.ic_add) // ic_add를 적절한 플레이스홀더로 변경
+                        ?: imageView.setImageResource(R.drawable.ic_add)
                 } else { imageView.setImageResource(R.drawable.ic_add) }
             } else { imageView.setImageResource(R.drawable.ic_add) }
         } ?: imageView.setImageResource(R.drawable.ic_add)
 
-        // 각 TextView에 식품 정보 설정
         dialogView.findViewById<TextView>(R.id.textFoodName).text = "식품명: ${item.name}"
         dialogView.findViewById<TextView>(R.id.textExpiryDate).text = "소비기한: ${dateFormat.format(item.expiryDate)}"
         dialogView.findViewById<TextView>(R.id.textQuantity).text = "수량: ${item.quantity}"
-        // 카테고리 ID를 이름으로 변환하여 표시 (allCategoriesMap 사용)
         val categoryName = item.categoryId?.let { allCategoriesMap[it] } ?: "미지정"
-        dialogView.findViewById<TextView>(R.id.textCategory).text = "카테고리: $categoryName" // XML에 textCategory ID가 있어야 함
+        dialogView.findViewById<TextView>(R.id.textCategory).text = "카테고리: $categoryName"
         dialogView.findViewById<TextView>(R.id.textStorage).text = "보관 위치: ${item.storageLocation ?: ""}"
         dialogView.findViewById<TextView>(R.id.textPurchaseDate).text = "구매일: ${item.purchaseDate?.let { dateFormat.format(it) } ?: ""}"
         dialogView.findViewById<TextView>(R.id.textMemo).text = "메모: ${item.memo ?: ""}"
 
-        // 태그 표시 (dialog_food_detail.xml에 textViewDialogTags ID가 있어야 함)
         val tagsTextView = dialogView.findViewById<TextView>(R.id.textViewDialogTags)
         if (item.tags.isNotEmpty()) {
             tagsTextView.text = "태그: ${item.tags.joinToString(", ")}"
@@ -321,25 +237,22 @@ class HomeFragment : Fragment() {
             tagsTextView.visibility = View.GONE
         }
 
-        // AlertDialog 생성 및 표시
         AlertDialog.Builder(requireContext())
             .setTitle("식품 상세정보")
             .setView(dialogView)
-            .setPositiveButton("닫기", null) // "닫기" 버튼
-            .setNeutralButton("수정") { _, _ -> // "수정" 버튼 -> AddFoodBottomSheetFragment 실행
-                val editFragment = AddFoodBottomSheetFragment.newInstance(item.id) // item.id 전달
+            .setPositiveButton("닫기", null)
+            .setNeutralButton("수정") { _, _ ->
+                val editFragment = AddFoodBottomSheetFragment.newInstance(item.id)
                 editFragment.show(parentFragmentManager, AddFoodBottomSheetFragment.TAG_EDIT)
             }
-            .setNegativeButton("삭제") { _, _ -> // "삭제" 버튼 -> 삭제 확인 다이얼로그 호출
+            .setNegativeButton("삭제") { _, _ ->
                 showDeleteConfirmationDialog(item)
             }
             .create().show()
     }
 
-    // Fragment의 View가 파괴될 때 호출됨 (메모리 누수 방지)
     override fun onDestroyView() {
-        Log.d("HomeFragmentLifecycle", "onDestroyView called")
         super.onDestroyView()
-        _binding = null // _binding 참조를 명시적으로 해제하여 메모리 누수 방지
+        _binding = null
     }
 }

--- a/FreshBox/app/src/main/res/drawable/ic_manage_categories.xml
+++ b/FreshBox/app/src/main/res/drawable/ic_manage_categories.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83l3.75,3.75L20.71,7.04z"/>
+</vector>

--- a/FreshBox/app/src/main/res/layout/fragment_home.xml
+++ b/FreshBox/app/src/main/res/layout/fragment_home.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?android:attr/colorBackground" tools:context=".ui.list.HomeFragment">
+    android:background="?android:attr/colorBackground"
+    tools:context=".ui.list.HomeFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/topBar"
@@ -26,6 +27,20 @@
             app:layout_constraintBottom_toBottomOf="parent" />
 
         <ImageView
+            android:id="@+id/imageViewManageCategories"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_manage_categories"
+            android:contentDescription="카테고리 관리"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:focusable="true"
+            app:tint="?attr/colorOnSurface"
+            app:layout_constraintEnd_toStartOf="@id/imageViewSettings"
+            app:layout_constraintTop_toTopOf="@id/imageViewSettings"
+            app:layout_constraintBottom_toBottomOf="@id/imageViewSettings"
+            android:layout_marginEnd="16dp" />
+        <ImageView
             android:id="@+id/imageViewSettings"
             android:layout_width="24dp"
             android:layout_height="24dp"
@@ -46,14 +61,15 @@
         android:layout_marginTop="8dp"
         app:layout_constraintTop_toBottomOf="@id/topBar"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/textFieldCategoryFilter"> <com.google.android.material.textfield.TextInputEditText
-        android:id="@+id/editTextSearch"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="식품 검색 (이름, 태그 등)"
-        android:inputType="text"
-        android:maxLines="1"
-        android:imeOptions="actionSearch"/>
+        app:layout_constraintEnd_toStartOf="@+id/textFieldCategoryFilter">
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editTextSearch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="식품 검색 (이름, 태그 등)"
+            android:inputType="text"
+            android:maxLines="1"
+            android:imeOptions="actionSearch"/>
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout


### PR DESCRIPTION
FreshBox 주간 보고서: 테마 변경 후 UI 비동작 버그 분석 및 해결
1. 문제 현상

애플리케이션의 홈 화면(HomeFragment)에서 사용자가 테마를 라이트/다크 모드로 변경할 경우, '카테고리'를 선택하는 드롭다운 메뉴(AutoCompleteTextView)가 터치에 반응하지 않고 목록이 나타나지 않는 심각한 UI 버그가 발생했습니다. 테마 변경은 activity.recreate() 메서드를 호출하여 액티비티를 재생성하는 방식으로 구현되어 있으며, 이 과정에서 UI 상태에 문제가 생기는 것으로 파악되었습니다.

2. 원인 분석 과정

초기에는 액티비티 재생성 시 발생하는 단순한 데이터 손실 문제로 판단했습니다. ArrayAdapter에 데이터가 제대로 채워지지 않는다고 가정하고, LiveData를 관찰하여 어댑터의 데이터를 갱신(clear(), addAll())하는 방식으로 1차 수정을 진행했습니다. 하지만 이 방법으로 문제가 해결되지 않았습니다.

더 깊은 분석 결과, 문제는 데이터가 아닌 ArrayAdapter 객체 자체의 상태 문제임이 밝혀졌습니다. 안드로이드에서 recreate()가 호출되어 Fragment가 재생성될 때, AutoCompleteTextView에 연결된 어댑터가 내부적으로 유효하지 않은 이전 상태나 컨텍스트(Context)를 참조하게 되어 드롭다운 UI(정확히는 PopupWindow)를 생성하는 데 실패한 것입니다. 즉, 어댑터의 데이터는 정상적으로 채워졌을지라도, 어댑터 객체 자체가 화면에 드롭다운을 그리는 기능을 상실한 상태였습니다.

3. 해결 방안

이러한 생명주기(Lifecycle)와 컨텍스트(Context) 종속적인 문제를 해결하기 위해, 기존 어댑터의 상태를 갱신하려는 시도를 버리고 더 확실한 방법을 선택했습니다.

데이터가 갱신될 때마다 완전히 새로운 ArrayAdapter 객체를 생성하여 AutoCompleteTextView에 다시 설정하는 방식으로 로직을 변경했습니다.

기존 코드의 문제점:
setupCategoryFilter()에서 어댑터를 한 번 생성하고, observeViewModel()에서 해당 어댑터의 내용물만 바꾸려고 시도했습니다. 이 방식은 어댑터의 내부 상태가 꼬였을 때 문제를 해결할 수 없습니다.

수정된 코드의 핵심:
observeViewModel()의 allCategories 관찰 블록 안에서, 카테고리 목록을 받을 때마다 매번 ArrayAdapter를 새로 생성하고 setAdapter()를 통해 UI에 연결해 주었습니다.

// main/java/com/example/freshbox/ui/list/HomeFragment.kt 의 수정된 로직
viewModel.allCategories.observe(viewLifecycleOwner) { categories ->
    // ... 카테고리 이름 목록 생성 ...

    // 매번 새로운 어댑터를 생성하여 UI에 다시 설정
    val newAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_dropdown_item_1line, categoryNames)
    binding.autoCompleteCategoryFilter.setAdapter(newAdapter)
}

이 방식은 기존 어댑터가 가질 수 있는 모든 잠재적인 상태 문제를 원천적으로 회피합니다. AutoCompleteTextView는 항상 최신 데이터와 유효한 컨텍스트로 만들어진 '깨끗한' 어댑터를 사용하게 되므로, 드롭다운 메뉴가 안정적으로 표시됩니다.

4. 결론

이번 버그 해결을 통해 안드로이드의 생명주기와 recreate() 과정에서 발생하는 컨텍스트 종속적인 UI 컴포넌트의 상태 관리 중요성을 다시 한번 확인했습니다. 단순히 데이터를 갱신하는 것만으로는 부족하며, 때로는 컴포넌트 자체를 새로 생성하여 연결하는 것이 더 안정적인 해결책이 될 수 있다는 교훈을 얻었습니다. 이 수정으로 인해 앱의 안정성이 크게 향상되었습니다.